### PR TITLE
Multiple docker hub images

### DIFF
--- a/Containerfile-12
+++ b/Containerfile-12
@@ -1,0 +1,8 @@
+# For more information and license, see: https://github.com/wise-home/postgres_wisehome
+# For more information about the parent postgres image, see: https://hub.docker.com/_/postgres
+# The purpose of the image is to add additional locales to the postgres image
+
+FROM postgres:12
+RUN localedef -i da_DK -c -f UTF-8 -A /usr/share/locale/locale.alias da_DK.UTF-8
+LABEL org.opencontainers.image.description="Postgres with danish locales. Only for internal use at Wise Home. See https://github.com/wise-home/postgres_wisehome for license."
+LABEL org.opencontainers.image.source="https://github.com/wise-home/postgres_wisehome"

--- a/Containerfile-9.6
+++ b/Containerfile-9.6
@@ -1,0 +1,8 @@
+# For more information and license, see: https://github.com/wise-home/postgres_wisehome
+# For more information about the parent postgres image, see: https://hub.docker.com/_/postgres
+# The purpose of the image is to add additional locales to the postgres image
+
+FROM postgres:9.6
+RUN localedef -i da_DK -c -f UTF-8 -A /usr/share/locale/locale.alias da_DK.UTF-8
+LABEL org.opencontainers.image.description="Postgres with danish locales. Only for internal use at Wise Home. See https://github.com/wise-home/postgres_wisehome for license."
+LABEL org.opencontainers.image.source="https://github.com/wise-home/postgres_wisehome"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-# This is the wisehome/postgres_with_locales Dockerfile
-
-# For more information and license, see: https://github.com/wise-home/postgres_with_locales
-# For more information about the parent postgres image, see: https://hub.docker.com/_/postgres
-
-# The purpose of the image is to add additional locales to the postgres image
-
-FROM postgres:9.6
-RUN localedef -i da_DK -c -f UTF-8 -A /usr/share/locale/locale.alias da_DK.UTF-8

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Docker Image for Postgres 9.6 with Locales
+# Docker Image for Postgres with danish locales
 
-This repository creates a postgres docker image based on the [official postgres image](https://hub.docker.com/_/postgres) and adds additional locales to it.
+The `Containerfile` in this repository creates a postgres docker image based on the [official postgres image](https://hub.docker.com/_/postgres) and adds additional locales to it.
 
-This project is only intended for internal use at Wise Home. Use at your own risk.
-
-The corresponding image on Docker Hub can be found here: [wisehome/postgres_wisehome](https://hub.docker.com/r/wisehome/postgres_wisehome)
+**This project is only intended for internal use at Wise Home. Use at your own risk.**
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The `Containerfile` in this repository creates a postgres docker image based on 
 
 This image is just a small addition to the official Postgres Docker image. The license for the official Postgres Docker image can be found [here](https://github.com/docker-library/docs/blob/master/postgres/README.md#license).
 
-The license for the code in the Dockerfile in this GitHub repository is MIT, as stated in [LICENSE](https://github.com/wise-home/postgres_wisehome/blob/master/LICENSE)
+The license for the containerfiles, container images and scripts in this GitHub repository is MIT, as stated in [LICENSE](https://github.com/wise-home/postgres_wisehome/blob/master/LICENSE)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script builds the wisehome/postgres_wisehome container image using podman in both versions
+
+set -e
+
+echo ""
+echo "Building postgres_wisehome:9.6"
+podman pull --tls-verify=true docker.io/library/postgres:9.6
+podman build . -t docker.io/wisehome/postgres_wisehome:9.6 -f Containerfile-9.6
+
+echo ""
+echo "Building postgres_wisehome:12"
+podman pull --tls-verify=true docker.io/library/postgres:12
+podman build . -t docker.io/wisehome/postgres_wisehome:12 -f Containerfile-12
+
+echo ""
+echo "Authenticating with Docker Hub and pushing images"
+podman login --tls-verify=true docker.io
+podman push --tls-verify=true docker.io/wisehome/postgres_wisehome:9.6
+podman push --tls-verify=true docker.io/wisehome/postgres_wisehome:12
+
+echo ""
+echo "All done."


### PR DESCRIPTION
This PR introduces support for two different tags, `9.6` and `12` instead of `latest`.

In addition small changes to README.md have been made and a build script is added for easy manual rebuilding.